### PR TITLE
Include tokenization_method in generated card tokens by default

### DIFF
--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -14,7 +14,7 @@ module StripeMock
       end
 
       def generate_card_token(card_params={})
-        card_data = { :number => "4242424242424242", :exp_month => 9, :exp_year => 2018, :cvc => "999" }
+        card_data = { :number => "4242424242424242", :exp_month => 9, :exp_year => 2018, :cvc => "999", :tokenization_method => nil }
         card = StripeMock::Util.card_merge(card_data, card_params)
         card[:fingerprint] = StripeMock::Util.fingerprint(card[:number]) if StripeMock.state == 'local'
 

--- a/spec/shared_stripe_examples/card_token_examples.rb
+++ b/spec/shared_stripe_examples/card_token_examples.rb
@@ -12,6 +12,7 @@ shared_examples 'Card Token Mocking' do
       expect(card.last4).to eq("4242")
       expect(card.exp_month).to eq(4)
       expect(card.exp_year).to eq(2016)
+      expect(card.tokenization_method).to eq(nil)
     end
 
     it "generates and reads a card token for create charge" do


### PR DESCRIPTION
in order to more accurately represent the data structure of live Stripe cards

- tokenization_method is used to distinguish between Stripe payment
methods, and might be the only way to determine when one of the non-CC
payment types (e.g. Apple Pay) are used
- enables specific testing of these payment types
```ruby
def apple_pay?
  Stripe::Token.retrieve(payment_gateway_token).card.tokenization_method == 'apple_pay'
end
```